### PR TITLE
Dispatch clear loading for empty query snapshots in watchCol

### DIFF
--- a/src/store/collections/actions.js
+++ b/src/store/collections/actions.js
@@ -2,7 +2,7 @@ import * as types from './types'
 import * as selectors from './selectors'
 import * as initSelectors from '../initialization/selectors'
 import { logError } from '../errors/actions'
-import { logLoading } from '../loadings/actions'
+import { logLoading, clearLoading } from '../loadings/actions'
 
 export const initialize = (list, location, path, locationValue, append) => {
   return {
@@ -86,6 +86,9 @@ export function watchCol(firebaseApp, firebasePath, reduxPath = false, append = 
       dispatch(logLoading(location))
       const unsub = ref.onSnapshot(
         snapshot => {
+          if (snapshot.size === 0) {
+            dispatch(clearLoading(location))
+          }
           snapshot.docChanges().forEach(change => {
             if (change.type === 'added') {
               if (initialized) {

--- a/src/store/collections/actions.spec.js
+++ b/src/store/collections/actions.spec.js
@@ -20,6 +20,29 @@ describe('collections actions', () => {
     expect(actions.watchCol(firebase, 'path', 'path2')).toBeA('function')
   })
 
+  it('watchCol should dispatch clearLoading if the query snapshot has no documents', () => {
+    const dispatch = expect.createSpy()
+    const getState = () => ({ initialization: {} })
+    const firebaseMock = {
+      firestore: () => ({
+        collection: () => ({
+          onSnapshot: ((handler) => {
+            const snapshot = {
+              size: 0,
+              docChanges: () => []
+            }
+            handler(snapshot)
+          })
+        }),
+      })
+    }
+    actions.watchCol(firebaseMock, 'path')(dispatch, getState)
+
+    // expect(dispatch.calls.length).toEqual(2)
+    expect(dispatch).toHaveBeenCalledWith({type: '@@firekit/LOADING@LOG_LOADING', location: 'path'})
+    expect(dispatch).toHaveBeenCalledWith({type: '@@firekit/LOADING@CLEAR_LOADING', location: 'path'})
+  });
+
   it('destroyCol should call dispatch 7 time', () => {
     const getState = () => ({ initialization: { path1: 'path1', path2: 'path2' } })
     const dispatch = expect.createSpy()


### PR DESCRIPTION
When a firestore query returns an empty snapshot the state should be updated to indicate that the query is finished loading. The current behaviour is to dispatch actions that clear the loadings state on document changes or errors and these actions are not dispatched if snapshot.docChanges() returns an empty array.