### PR TITLE
Updated actions getPath return ref.path to resolve undefined when passing ref

### DIFF
--- a/src/store/collections/actions.js
+++ b/src/store/collections/actions.js
@@ -53,8 +53,8 @@ export const unWatch = path => {
   }
 }
 
-const getPath = (firebaseApp, ref) => {
-  return ref._query.path.segments.join('/')
+const getPath = (ref) => {
+  return ref.path
 }
 
 export const getRef = (firebaseApp, path) => {
@@ -65,17 +65,17 @@ export const getRef = (firebaseApp, path) => {
   }
 }
 
-export const getLocation = (firebaseApp, path) => {
+export const getLocation = (path) => {
   if (typeof path === 'string' || path instanceof String) {
     return path
   } else {
-    return getPath(firebaseApp, path)
+    return getPath(path)
   }
 }
 
 export function watchCol(firebaseApp, firebasePath, reduxPath = false, append = false) {
   let ref = getRef(firebaseApp, firebasePath)
-  const path = getLocation(firebaseApp, firebasePath)
+  const path = getLocation(firebasePath)
   let location = reduxPath || path
 
   return (dispatch, getState) => {
@@ -172,7 +172,7 @@ export function unwatchCol(firebaseApp, firebasePath) {
 
 export function destroyCol(firebaseApp, firebasePath, reduxPath = false) {
   return (dispatch, getState) => {
-    const location = reduxPath || getLocation(firebaseApp, firebasePath)
+    const location = reduxPath || getLocation(firebasePath)
     const locations = getState().initialization[location]
 
     dispatch(unWatch(location))


### PR DESCRIPTION
Thanks again for your awesome library Tarik!

Maybe I am passing in the wrong object or firestore updated their API.  
When passing in a collection ref as a query or ref to watchCol, throws an exception when hitting the line 57: return ref._query.path.segments.join('/'); TypeError: Cannot read property 'path' of undefined.

Modified from CollectionActivity example https://github.com/TarikHuber/react-most-wanted/blob/master/packages/rmw-shell/src/containers/Activities/CollectionActivity.js
// ...
class CollectionActivity extends Component {
  componentDidMount() {
    const { path, name, watchCol, firebaseApp, firebaseApp: { firebase_ }, auth } = this.props
// ...
// **Use case 1:**
const ref = firebase_.firestore().collection(path || name);
watchCol(ref);

// **Use case 2:**
const query = firebase_.firestore().collection(path || name).where("author", "==",  auth.uid);
watchCol(query);

// **Use case 3:**
const ref = firebase_.firestore().collection(path || name);
watchCol(ref, "tasks");

// **Use case 4:**
const query = firebase_.firestore().collection(path || name).where("author", "==",  auth.uid);
watchCol(query, "tasks");

~/node_modules/firekit/es/store/collections/actions.js
var getPath = function getPath(firebaseApp, ref) {
  return ref._query.path.segments.join('/');  **//TypeError: Cannot read property 'path' of undefined**
};